### PR TITLE
Remove env variables from login page; Ngrok setup

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -118,9 +118,6 @@ services:
       - "traefik.http.routers.login.rule=PathPrefix(`/login`)"
       - "traefik.http.routers.login.middlewares=login-strip-prefix"
       - "traefik.http.middlewares.login-strip-prefix.stripprefix.prefixes=/login"
-    environment:
-      - VITE_TOKEN_URL=http://localhost/token
-      - VITE_REDIRECT_URL=http://localhost/validate
 
 networks:
   default:

--- a/dt-demo-gcp-login/src/App.tsx
+++ b/dt-demo-gcp-login/src/App.tsx
@@ -34,9 +34,8 @@ interface ApiResult {
   payload: SuccessPayload | ErrorPayload;
 }
 
-const tokenUrl = import.meta.env.VITE_TOKEN_URL ?? "http://localhost/token";
-const redirectURL =
-  import.meta.env.VITE_REDIRECT_URL ?? "http://localhost/validate";
+const tokenUrl = "https://yc.ngrok.dev/token";
+const redirectURL = "https://yc.ngrok.dev/validate";
 
 function copyright() {
   /** Render the copyright notice. */
@@ -205,8 +204,6 @@ export default function App() {
 
     /** Check for a valid access token and redirect if valid. */
     const validateToken = async () => {
-      const redirectURL =
-        import.meta.env.VITE_REDIRECT_URL ?? "http://localhost/validate";
       const token = document.cookie
         .split("; ")
         .find((row) => row.startsWith("access_token="))


### PR DESCRIPTION
- Cannot use env variables as page is compiled to static and runs client-side.
- Currently hard-coded to use `yc.ngrok.dev` for TLS termination testing.